### PR TITLE
No tuple creation for SizedArrays

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -154,6 +154,7 @@ reshape(a::Array, s::Size{S}) where {S} = s(a)
 @inline vec(a::StaticArray) = reshape(a, Size(prod(Size(typeof(a)))))
 
 @inline copy(a::StaticArray) = typeof(a)(Tuple(a))
+@inline copy(a::SizedArray) = typeof(a)(a)
 
 # TODO permutedims?
 


### PR DESCRIPTION
Tuple creation is unnecessary for `SizedArrays` and causes massive slowdown for big arrays.